### PR TITLE
make compatible with latest bidict

### DIFF
--- a/paylogic_genres/paylogic_genres.py
+++ b/paylogic_genres/paylogic_genres.py
@@ -12,7 +12,7 @@ def _set_genre_cache():
 
 
 def convert_ecc_to_code(ecc):
-    return _GENRE_CACHE[:ecc]
+    return _GENRE_CACHE.inv[ecc]
 
 
 def convert_code_to_ecc(code):


### PR DESCRIPTION
slice syntax was removed in [0.10.0](https://bidict.readthedocs.org/en/master/changelog.html#id2)
